### PR TITLE
Added new variations of output and control of the JSON field

### DIFF
--- a/app/MoonShine/Pages/UI/JsonPage.php
+++ b/app/MoonShine/Pages/UI/JsonPage.php
@@ -9,10 +9,12 @@ use Illuminate\Database\Eloquent\Model;
 use MoonShine\Contracts\Core\DependencyInjection\CrudRequestContract;
 use MoonShine\Contracts\UI\FieldContract;
 use MoonShine\Crud\JsonResponse;
+use MoonShine\Laravel\Collections\Fields;
 use MoonShine\Laravel\Pages\Page;
 use MoonShine\MenuManager\Attributes\Group;
 use MoonShine\MenuManager\Attributes\Order;
 use MoonShine\Support\Attributes\AsyncMethod;
+use MoonShine\UI\Components\ActionButton;
 use MoonShine\UI\Components\FormBuilder;
 use MoonShine\UI\Components\Layout\Box;
 use MoonShine\UI\Components\Layout\Column;
@@ -28,7 +30,6 @@ use MoonShine\UI\Fields\Number;
 use MoonShine\UI\Fields\Select;
 use MoonShine\UI\Fields\Switcher;
 use MoonShine\UI\Fields\Text;
-use MoonShine\Laravel\Collections\Fields;
 
 #[Group('UI')]
 #[Order(6)]
@@ -69,6 +70,8 @@ class JsonPage extends Page
             'key-value' => $this->keyValueFields(),
             'only-value' => $this->onlyValueFields(),
             'object' => $this->objectFields(),
+            'create-button-options' => $this->createButtonOptionsFields(),
+            'display-options' => $this->displayOptionsFields(),
             'mixed-object' => $this->mixedObjectFields(),
             'mixed-default' => $this->mixedDefaultFields(),
             default => $this->defaultFields(),
@@ -88,7 +91,7 @@ class JsonPage extends Page
 
         return JsonResponse::make()
             ->html([
-                '.after-apply-json' => "<code>" . json_encode($data->getAttributes(), JSON_THROW_ON_ERROR) . "</code>"
+                '.after-apply-json' => '<code>'.json_encode($data->getAttributes(), JSON_THROW_ON_ERROR).'</code>',
             ]);
     }
 
@@ -154,6 +157,31 @@ class JsonPage extends Page
                 ])->columnSpan(6),
 
                 Column::make([
+                    Box::make('Table (Preview)', [
+                        $this->tableFields()
+                            ->findByColumn('data')
+                            ?->fillData($this->tableFill()),
+                    ]),
+                ])->columnSpan(6),
+
+                Column::make([
+                    Box::make('Create Button Options', [
+                        $this->form(
+                            $this->createButtonOptionsFields(),
+                        ),
+                    ]),
+                ])->columnSpan(6),
+
+                Column::make([
+                    Box::make('Display Options', [
+                        $this->form(
+                            $this->displayOptionsFields(),
+                            $this->displayOptionsFill(),
+                        ),
+                    ]),
+                ])->columnSpan(12),
+
+                Column::make([
                     Box::make('Mixed Object', [
                         $this->form(
                             $this->mixedObjectFields(),
@@ -172,9 +200,9 @@ class JsonPage extends Page
                         $this->mixedObjectFields()
                             ->findByColumn('data')
                             ?->previewMode()
-                            ?->fillData($this->mixedObjectFill())
+                            ?->fillData($this->mixedObjectFill()),
                     ]),
-                ])->columnSpan(12),
+                ])->columnSpan(6),
 
                 Column::make([
                     Box::make('Mixed Default', [
@@ -190,15 +218,211 @@ class JsonPage extends Page
                 ])->columnSpan(12),
 
                 Column::make([
+                    Box::make('Nested Table (Preview)', [
+
+                        $this->nestedTableFields()
+                            ->findByColumn('data')
+                            ?->fillData($this->nestedTableFill()),
+                    ]),
+                ])->columnSpan(12),
+
+                Column::make([
                     Box::make('Mixed Default (Preview)', [
 
                         $this->mixedDefaultFields()
                             ->findByColumn('data')
                             ?->previewMode()
-                            ?->fillData($this->mixedDefaultFill())
+                            ?->fillData($this->mixedDefaultFill()),
                     ]),
                 ])->columnSpan(12),
             ]),
+        ];
+    }
+
+    private function displayOptionsFields(): Fields
+    {
+        return Fields::make([
+            Hidden::make('_type')->setValue('display-options'),
+
+            Json::make('Vertical orientation', 'vertical_orientation')
+                ->fields([
+                    Text::make('Title'),
+                    Text::make('Value'),
+                ], 'vertical'),
+
+            Json::make('Reorderable', 'reorderable')
+                ->fields([
+                    Text::make('Title'),
+                    Text::make('Value'),
+                ])
+                ->reorderable(),
+
+            Json::make('Custom buttons', 'custom_buttons')
+                ->fields([
+                    Text::make('Title'),
+                    Text::make('Value'),
+                ])
+                ->buttons([
+                    ActionButton::make('Remove')
+                        ->icon('trash')
+                        ->onClick(fn (): string => 'remove()', 'prevent')
+                        ->error()
+                        ->showInLine(),
+                ]),
+
+            Json::make('Custom empty message', 'custom_empty_message')
+                ->fields([
+                    Text::make('Title'),
+                    Text::make('Value'),
+                ])
+                ->emptyMessage('No demo rows'),
+        ]);
+    }
+
+    private function displayOptionsFill(): array
+    {
+        return [
+            'vertical_orientation' => [
+                [
+                    'title' => 'Vertical row',
+                    'value' => 'Fields are stacked',
+                ],
+            ],
+            'reorderable' => [
+                [
+                    'title' => 'First',
+                    'value' => 'Drag me',
+                ],
+                [
+                    'title' => 'Second',
+                    'value' => 'Drag me too',
+                ],
+            ],
+            'custom_buttons' => [
+                [
+                    'title' => 'Custom action',
+                    'value' => 'Uses custom row button',
+                ],
+            ],
+            'custom_empty_message' => [],
+        ];
+    }
+
+    private function createButtonOptionsFields(): Fields
+    {
+        return Fields::make([
+            Hidden::make('_type')->setValue('create-button-options'),
+
+            Json::make('Icon only with Limit', 'icon_only')
+                ->fields([
+                    Text::make('Title'),
+                    Text::make('Value'),
+                ])
+                ->creatable(limit: 2, showButtonText: false),
+
+            Json::make('Text only', 'text_only')
+                ->fields([
+                    Text::make('Title'),
+                    Text::make('Value'),
+                ])
+                ->creatable(showButtonIcon: false),
+
+            Json::make('Hidden add button', 'hidden_add_button')
+                ->fields([
+                    Text::make('Title'),
+                    Text::make('Value'),
+                ])
+                ->creatable(hideButton: true),
+        ]);
+    }
+
+    private function tableFields(): Fields
+    {
+        return Fields::make([
+            Json::make('Data')
+                ->fields([
+                    Text::make('Title'),
+                    Select::make('Status')->options([
+                        'draft' => 'Draft',
+                        'published' => 'Published',
+                    ]),
+                    Number::make('Stock')->nullable(),
+                    Switcher::make('Active'),
+                ])
+                ->table(),
+        ]);
+    }
+
+    private function tableFill(): array
+    {
+        return [
+            'data' => [
+                [
+                    'title' => 'First product',
+                    'status' => 'draft',
+                    'stock' => 10,
+                    'active' => true,
+                ],
+                [
+                    'title' => 'Second product',
+                    'status' => 'published',
+                    'stock' => 25,
+                    'active' => false,
+                ],
+            ],
+        ];
+    }
+
+    private function nestedTableFields(): Fields
+    {
+        return Fields::make([
+            Json::make('Data')
+                ->fields([
+                    Text::make('Name'),
+
+                    Json::make('Prices')
+                        ->fields([
+                            Number::make('Wholesale price'),
+                            Number::make('Retail price'),
+                            Switcher::make('Tax included'),
+                        ])
+                        ->object()
+                        ->table(),
+
+                    Json::make('Links')
+                        ->fields([
+                            Text::make('Label'),
+                            Text::make('Url'),
+                        ])
+                        ->table(),
+                ])
+                ->table(),
+        ]);
+    }
+
+    private function nestedTableFill(): array
+    {
+        return [
+            'data' => [
+                [
+                    'name' => 'Product 1',
+                    'prices' => [
+                        'wholesale_price' => 1000,
+                        'retail_price' => 1200,
+                        'tax_included' => true,
+                    ],
+                    'links' => [
+                        [
+                            'label' => 'Docs',
+                            'url' => 'https://moonshine-laravel.com',
+                        ],
+                        [
+                            'label' => 'GitHub',
+                            'url' => 'https://github.com/moonshine-software',
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -221,7 +445,7 @@ class JsonPage extends Page
             'data' => [
                 ['title' => 'Title 1', 'value' => 'Value 1'],
                 ['title' => 'Title 2', 'value' => 'Value 2'],
-            ]
+            ],
         ];
     }
 
@@ -241,7 +465,7 @@ class JsonPage extends Page
                 'key 1' => 'value 1',
                 'key 2' => 'value 2',
                 'key 3' => 'value 3',
-            ]
+            ],
         ];
     }
 
@@ -261,7 +485,7 @@ class JsonPage extends Page
                 'value 1',
                 'value 2',
                 'value 3',
-            ]
+            ],
         ];
     }
 
@@ -278,7 +502,7 @@ class JsonPage extends Page
                     Text::make('One'),
                     Text::make('Two'),
                     Number::make('Number')->step(0.1)->nullable(),
-                    Switcher::make('Active')
+                    Switcher::make('Active'),
                 ])->object(),
             ])->object(),
         ]);
@@ -293,8 +517,8 @@ class JsonPage extends Page
                 'inner' => [
                     'one' => 'One',
                     'two' => 'Two',
-                ]
-            ]
+                ],
+            ],
         ];
     }
 
@@ -330,9 +554,9 @@ class JsonPage extends Page
                         'key 1' => 'value 1',
                         'key 2' => 'value 2',
                         'key 3' => 'value 3',
-                    ]
-                ]
-            ]
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -353,7 +577,7 @@ class JsonPage extends Page
                             Flex::make([
                                 Text::make('One'),
                                 Text::make('Two'),
-                            ])
+                            ]),
                         ]),
 
                         Select::make('Multiple')->options([1 => 1, 2 => 2, 3 => 3])->multiple(),
@@ -361,7 +585,7 @@ class JsonPage extends Page
                         Json::make('KV')->keyValue(),
                     ])->object(),
                 ])->object(),
-            ])
+            ]),
         ]);
     }
 
@@ -381,9 +605,9 @@ class JsonPage extends Page
                                 'key 1' => 'value 1',
                                 'key 2' => 'value 2',
                                 'key 3' => 'value 3',
-                            ]
-                        ]
-                    ]
+                            ],
+                        ],
+                    ],
                 ],
                 [
                     'title' => 'Title 2',
@@ -397,11 +621,11 @@ class JsonPage extends Page
                                 'key 1 2' => 'value 1 2',
                                 'key 2 2' => 'value 2 2',
                                 'key 3 2' => 'value 3 2',
-                            ]
-                        ]
-                    ]
-                ]
-            ]
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Field PR [#2038](https://github.com/moonshine-software/moonshine/pull/2038)
Doc PR [#1034](https://github.com/moonshine-software/doc/pull/1034)

- Expanded the Json field demo page in the devkit.
- Added preview examples for table-based Json output.
- Added a nested table preview example with object and list Json fields.
- Added examples for create button configuration, including icon-only, text-only, limited, and hidden add button states.
- Added display option examples for vertical orientation, reorderable rows, custom row buttons, and custom empty messages.
